### PR TITLE
add lint support for styled() constructor

### DIFF
--- a/lib/rules/sort-declarations-alphabetically.js
+++ b/lib/rules/sort-declarations-alphabetically.js
@@ -4,7 +4,8 @@ const postcss = require("postcss");
 function isStyledTagname(node) {
   return (
     (node.tag.type === "Identifier" && node.tag.name === "css") ||
-    (node.tag.type === "MemberExpression" && node.tag.object.name === "styled")
+    (node.tag.type === "MemberExpression" && node.tag.object.name === "styled") ||
+    (node.tag.type === "CallExpression" && node.tag.callee.name === "styled")
   );
 }
 

--- a/tests/lib/rules/sort-declarations-alphabetically.js
+++ b/tests/lib/rules/sort-declarations-alphabetically.js
@@ -25,6 +25,10 @@ ruleTester.run("sort-declarations-alphabetically", rule, {
       parserOptions
     },
     {
+      code: "const button = styled(Button)`height: 200px; width: 300px;`",
+      parserOptions
+    },
+    {
       code: "const button = css`height: 200px; width: 300px;`",
       parserOptions
     },
@@ -80,6 +84,16 @@ ruleTester.run("sort-declarations-alphabetically", rule, {
         }
       ],
       output: "const button = styled.button`height: 200px; width: 300px;`"
+    },
+    {
+      code: "const button = styled(Button)`width: 300px; height: 200px;`",
+      parserOptions,
+      errors: [
+        {
+          messageId: "sort-declarations-alphabetically"
+        }
+      ],
+      output: "const button = styled(Button)`height: 200px; width: 300px;`"
     },
     {
       code: "const button = css`width: 300px; height: 200px;`",


### PR DESCRIPTION
This solves https://github.com/siffogh/eslint-plugin-better-styled-components/issues/1.

This change accommodates expressions like:
```jsx
const StyledButton = styled(Button)`
  padding: 10px;
  margin: 10px;
`
```